### PR TITLE
Update two-color poly-g trimming list for new sequencers

### DIFF
--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -21,8 +21,13 @@ bool Evaluator::isTwoColorSystem() {
     if(!r)
         return false;
 
-    // NEXTSEQ500, NEXTSEQ 550/550DX, NOVASEQ
-    if(starts_with(r->mName, "@NS") || starts_with(r->mName, "@NB") || starts_with(r->mName, "@NDX") || starts_with(r->mName, "@A0")) {
+    // Via https://knowledge.illumina.com/instrumentation/general/instrumentation-general-reference_material-list/000003880
+    // NEXTSEQ 500/550: @NS @NB
+    // ? NEXTSEQ 550DX: @NDX
+    // NEXTSEQ 1000/2000: @VL @VH
+    // NOVASEQ 6000: @A
+    // NOVASEQ X PLUS: @LH
+    if(starts_with(r->mName, "@NS") || starts_with(r->mName, "@NB") || starts_with(r->mName, "@NDX") || starts_with(r->mName, "@VL") || starts_with(r->mName, "@VH") || starts_with(r->mName, "@A") || starts_with(r->mName, "@LH")) {
         delete r;
         return true;
     }


### PR DESCRIPTION
This PR updates and expands the list of serial numbers of Illumina 2-color SBS sequencers for poly-g trimming.

These values come from: https://knowledge.illumina.com/instrumentation/general/instrumentation-general-reference_material-list/000003880

This expands the previous 2-color list by adding:

- NovaSeq 1000/2000 (`@VL @VH`)
- NovaSeq X Plus (`@LH`)

This also broadens the NovaSeq 6000 serial from (`@A0 --> @A`) per Illumina's doc.

(I do not see `@NDX` documented by illumina, but this might be their NextSeq 550Dx FDA-regulated sequencer.)